### PR TITLE
8347600: Change JavaFX release version to 24.0.1 in jfx24u

### DIFF
--- a/.jcheck/conf
+++ b/.jcheck/conf
@@ -24,7 +24,7 @@
 [general]
 project=openjfx
 jbs=jdk
-version=jfx24
+version=jfx24.0.1
 
 [repository]
 tags=(jdk-){0,1}([1-9]([0-9]*)(\.(0|[1-9][0-9]*)){0,3})(\+(([0-9]+))|(-ga))|[1-9]((\.\d{1,3}){0,2})-((b\d{2,3})|(ga))|[1-9]u(\d{1,3})-((b\d{2,3})|(ga))

--- a/build.properties
+++ b/build.properties
@@ -46,7 +46,7 @@ jfx.experimental.feature.name=
 # UPDATE THE FOLLOWING VALUES FOR A NEW RELEASE
 jfx.release.major.version=24
 jfx.release.minor.version=0
-jfx.release.security.version=0
+jfx.release.security.version=1
 jfx.release.patch.version=0
 
 # Note: The release version is now calculated in build.gradle as the


### PR DESCRIPTION
Updates for the beginning of the 24.0.1 release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8347600](https://bugs.openjdk.org/browse/JDK-8347600) needs maintainer approval

### Issue
 * [JDK-8347600](https://bugs.openjdk.org/browse/JDK-8347600): Change JavaFX release version to 24.0.1 in jfx24u (**Task** - P2 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/1.diff">https://git.openjdk.org/jfx24u/pull/1.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/1#issuecomment-2607795080)
</details>
