### PR TITLE
8350437: [GHA] Update gradle wrapper-validation action to v3

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v3
 
 
   linux_x64_build:


### PR DESCRIPTION
Clean backport of GHA-only fix to jfx24u.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8350437](https://bugs.openjdk.org/browse/JDK-8350437) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8350437](https://bugs.openjdk.org/browse/JDK-8350437): [GHA] Update gradle wrapper-validation action to v3 (**Bug** - P3 - Approved)


### Reviewers
 * [Johan Vos](https://openjdk.org/census#jvos) (@johanvos - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/8.diff">https://git.openjdk.org/jfx24u/pull/8.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/8#issuecomment-2675044359)
</details>
