### PR TITLE
8351368: RichTextArea: exception pasting from Word

### DIFF
--- a/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFReader.java
+++ b/modules/jfx.incubator.richtext/src/main/java/com/sun/jfx/incubator/scene/control/richtext/rtf/RTFReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -782,11 +782,11 @@ public class RTFReader extends RTFParser {
             HashMap<Integer, Style> secStyles = new HashMap<>();
             for (StyleDefiningDestination style : definedStyles.values()) {
                 Style defined = style.realize();
-                String stype = (String)defined.getAttribute(STYLE_TYPE);
+                Object stype = defined.getAttribute(STYLE_TYPE);
                 Map<Integer, Style> toMap;
-                if (stype.equals(STYLE_SECTION)) {
+                if (stype == STYLE_SECTION) {
                     toMap = secStyles;
-                } else if (stype.equals(STYLE_CHARACTER)) {
+                } else if (stype == STYLE_CHARACTER) {
                     toMap = chrStyles;
                 } else {
                     toMap = pgfStyles;


### PR DESCRIPTION
Clean backport of https://github.com/openjdk/jfx/pull/1731

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351368](https://bugs.openjdk.org/browse/JDK-8351368) needs maintainer approval

### Issue
 * [JDK-8351368](https://bugs.openjdk.org/browse/JDK-8351368): RichTextArea: exception pasting from Word (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/11.diff">https://git.openjdk.org/jfx24u/pull/11.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/11#issuecomment-2710919211)
</details>
