### PR TITLE
8351653: Webkit debug build failure after update to 620.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/platform/graphics/ImageFrameWorkQueue.cpp
@@ -89,13 +89,13 @@ void ImageFrameWorkQueue::start()
             callOnMainThread([protectedThis, protectedWorkQueue, protectedSource, request, nativeImage = WTFMove(nativeImage)] () mutable {
                 // The WorkQueue may have been recreated before the frame was decoded.
                 if (protectedWorkQueue.ptr() != protectedThis->m_workQueue || protectedSource.ptr() != protectedThis->m_source.get()) {
-                    LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. WorkQueue was recreated at index = %d.", __FUNCTION__, protectedThis.ptr(), protectedSource->sourceUTF8(), request.index);
+                    LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. WorkQueue was recreated at index = %d.", __FUNCTION__, protectedThis.ptr(), protectedSource->sourceUTF8().data(), request.index);
                     return;
                 }
 
                 // The DecodeQueue may have been cleared before the frame was decoded.
                 if (protectedThis->decodeQueue().isEmpty() || protectedThis->decodeQueue().first() != request) {
-                    LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. DecodeQueue was cleared at index = %d.", __FUNCTION__, protectedThis.ptr(), protectedSource->sourceUTF8(), request.index);
+                    LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. DecodeQueue was cleared at index = %d.", __FUNCTION__, protectedThis.ptr(), protectedSource->sourceUTF8().data(), request.index);
                     return;
                 }
 
@@ -126,7 +126,7 @@ void ImageFrameWorkQueue::stop()
     Ref source = protectedSource();
 
     for (auto& request : m_decodeQueue) {
-        LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. Decoding was cancelled for frame at index = %d.", __FUNCTION__, this, source->sourceUTF8(), request.index);
+        LOG(Images, "ImageFrameWorkQueue::%s - %p - url: %s. Decoding was cancelled for frame at index = %d.", __FUNCTION__, this, source->sourceUTF8().data(), request.index);
         source->destroyNativeImageAtIndex(request.index);
     }
 


### PR DESCRIPTION
A clean backport to jfx24u. This fixes debug build error on mac platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351653](https://bugs.openjdk.org/browse/JDK-8351653) needs maintainer approval

### Issue
 * [JDK-8351653](https://bugs.openjdk.org/browse/JDK-8351653): Webkit debug build failure after update to 620.1 (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/13.diff">https://git.openjdk.org/jfx24u/pull/13.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/13#issuecomment-2731691791)
</details>
