### PR TITLE
8351264: Some images don't load with WebKit 620.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -147,7 +147,10 @@ static String acceptHeaderValueForImageResource()
 {
     static MainThreadNeverDestroyed<String> staticPrefix = [] {
         StringBuilder builder;
+// Java platform failing to decode webp image data already disabled in 619.1
+#if (HAVE(WEBP) || USE(WEBP)) && !PLATFORM(JAVA)
         builder.append("image/webp,"_s);
+#endif
 #if HAVE(AVIF) || USE(AVIF)
         builder.append("image/avif,"_s);
 #endif


### PR DESCRIPTION
clean backport to jfx24u. The patch fixes image rendering issue on some websites that might have non compatible images for JavaFX Webkit platform.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8351264](https://bugs.openjdk.org/browse/JDK-8351264) needs maintainer approval

### Issue
 * [JDK-8351264](https://bugs.openjdk.org/browse/JDK-8351264): Some images don't load with WebKit 620.1 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/14.diff">https://git.openjdk.org/jfx24u/pull/14.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/14#issuecomment-2733128054)
</details>
