### PR TITLE
8353916: Unexpected event type for DOM mutation events with WebKit 620.1

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WebCore/dom/MutationEvent.h
+++ b/modules/javafx.web/src/main/native/Source/WebCore/dom/MutationEvent.h
@@ -58,6 +58,9 @@ public:
 private:
     MutationEvent();
     MutationEvent(const AtomString& type, CanBubble, IsCancelable, Node* relatedNode, const String& prevValue, const String& newValue);
+#if PLATFORM(JAVA) // FIXME-java: used in JavaEvent.cpp, or enable RTTI
+    bool isMutationEvent() const override final { return true; }
+#endif
 
     RefPtr<Node> m_relatedNode;
     String m_prevValue;


### PR DESCRIPTION
A clean backport to jfx24u , the patch fixes the mutation event typecast issue the change for supportig old style mutation event type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8353916](https://bugs.openjdk.org/browse/JDK-8353916) needs maintainer approval

### Issue
 * [JDK-8353916](https://bugs.openjdk.org/browse/JDK-8353916): Unexpected event type for DOM mutation events with WebKit 620.1 (**Bug** - P2 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/17.diff">https://git.openjdk.org/jfx24u/pull/17.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/17#issuecomment-2788853536)
</details>
