### PR TITLE
8350284: WebKit 620.1 crashes on startup on Windows x86 32-bit

### DIFF
--- a/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
+++ b/modules/javafx.web/src/main/native/Source/cmake/WebKitCompilerFlags.cmake
@@ -151,6 +151,10 @@ if (COMPILER_IS_GCC_OR_CLANG)
         # FIXME: These warnings should be addressed
         WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-sign-compare
                                              -Wno-deprecated-declarations)
+        # Disable SSE for 32-bit Windows on JAVA platform
+        if (WTF_CPU_X86 AND NOT CMAKE_CROSSCOMPILING)
+            WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-mno-sse)
+        endif ()
     else ()
         WEBKIT_APPEND_GLOBAL_COMPILER_FLAGS(-fno-exceptions)
         WEBKIT_APPEND_GLOBAL_CXX_FLAGS(-fno-rtti)


### PR DESCRIPTION
A clean backport to  jfx24u. The patch fixes startup issue of javafx web application on window i586 machine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8350284](https://bugs.openjdk.org/browse/JDK-8350284) needs maintainer approval

### Issue
 * [JDK-8350284](https://bugs.openjdk.org/browse/JDK-8350284): WebKit 620.1 crashes on startup on Windows x86 32-bit (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/18.diff">https://git.openjdk.org/jfx24u/pull/18.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/18#issuecomment-2789482583)
</details>
