### PR TITLE
8354182: Create release notes for JavaFX 24.0.1

### DIFF
--- a/doc-files/release-notes-24.0.1.md
+++ b/doc-files/release-notes-24.0.1.md
@@ -20,6 +20,4 @@ Issue key | Summary | Subcomponent
 
 ## List of Security fixes
 
-Issue key | Summary | Subcomponent
---------- | ------- | ------------
-JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT
+NONE

--- a/doc-files/release-notes-24.0.1.md
+++ b/doc-files/release-notes-24.0.1.md
@@ -1,0 +1,25 @@
+# Release Notes for JavaFX 24.0.1
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 24.0.1 update release. As such, they complement the [JavaFX 24](https://github.com/openjdk/jfx24u/blob/master/doc-files/release-notes-24.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+[JDK-8351368](https://bugs.openjdk.org/browse/JDK-8351368) | RichTextArea: exception pasting from Word | controls
+[JDK-8349256](https://bugs.openjdk.org/browse/JDK-8349256) | Update PipeWire to 1.3.81 | graphics
+[JDK-8340322](https://bugs.openjdk.org/browse/JDK-8340322) | Update WebKit to 620.1 | web
+[JDK-8347937](https://bugs.openjdk.org/browse/JDK-8347937) | Canvas pattern test fails and crashes on WebKit 620.1 | web
+[JDK-8349924](https://bugs.openjdk.org/browse/JDK-8349924) | Additional WebKit 620.1 fixes from WebKitGTK 2.46.6 | web
+[JDK-8351264](https://bugs.openjdk.org/browse/JDK-8351264) | Some images don't load with WebKit 620.1 | web
+
+
+## List of Security fixes
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT


### PR DESCRIPTION
Release notes for JavaFX 24.0.1.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=47358

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=47357

As usual, I excluded test bugs, cleanup bugs, etc.

NOTE: Once the CPU release ships on 2025-04-15, I will add any security bugs and ask for a re-review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354182](https://bugs.openjdk.org/browse/JDK-8354182) needs maintainer approval

### Issue
 * [JDK-8354182](https://bugs.openjdk.org/browse/JDK-8354182): Create release notes for JavaFX 24.0.1 (**Task** - P2 - Approved)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**) Review applies to [1b312d8f](https://git.openjdk.org/jfx24u/pull/19/files/1b312d8f9d7b86bdae37ef6c1c0203ecc059335a)
 * [Joeri Sykora](https://openjdk.org/census#sykora) (@tiainen - Author) Review applies to [1b312d8f](https://git.openjdk.org/jfx24u/pull/19/files/1b312d8f9d7b86bdae37ef6c1c0203ecc059335a)
 * [Ambarish Rapte](https://openjdk.org/census#arapte) (@arapte - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/19.diff">https://git.openjdk.org/jfx24u/pull/19.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/19#issuecomment-2791181951)
</details>
