### PR TITLE
8354318: freetype.c: compilation error: 'incompatible pointer type' with gcc 14

### DIFF
--- a/modules/javafx.graphics/src/main/native-font/freetype.c
+++ b/modules/javafx.graphics/src/main/native-font/freetype.c
@@ -520,7 +520,7 @@ static PathData* checkSize(void* user, int coordCount)
         if (info->lenCoords > SIZE_MAX - DEFAULT_LEN_COORDS) goto fail;
         info->lenCoords += DEFAULT_LEN_COORDS;
 
-        jbyte* newPointCoords = (jfloat*)realloc(info->pointCoords, info->lenCoords * sizeof(jfloat));
+        jfloat* newPointCoords = (jfloat*)realloc(info->pointCoords, info->lenCoords * sizeof(jfloat));
         if (newPointCoords == NULL) goto fail;
         info->pointCoords = newPointCoords;
     }


### PR DESCRIPTION
Clean backport of "incompatible pointer type" fix to jfx24u

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] [JDK-8354318](https://bugs.openjdk.org/browse/JDK-8354318) needs maintainer approval
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354318](https://bugs.openjdk.org/browse/JDK-8354318): freetype.c: compilation error: 'incompatible pointer type' with gcc 14 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/21/head:pull/21` \
`$ git checkout pull/21`

Update a local copy of the PR: \
`$ git checkout pull/21` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/21/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21`

View PR using the GUI difftool: \
`$ git pr show -t 21`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/21.diff">https://git.openjdk.org/jfx24u/pull/21.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/21#issuecomment-2802443075)
</details>
