### PR TITLE
8354336: gstclock.c: compilation error: 'incompatible pointer type' with gcc 14

### DIFF
--- a/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst_private.h
+++ b/modules/javafx.media/src/main/native/gstreamer/gstreamer-lite/gstreamer/gst/gst_private.h
@@ -532,7 +532,11 @@ struct _GstDynamicTypeFactoryClass {
 struct _GstClockEntryImpl
 {
   GstClockEntry entry;
+#if defined (GSTREAMER_LITE) && defined(LINUX)
+  GWeakRef clock;
+#else // GSTREAMER_LITE
   GWeakRef *clock;
+#endif // GSTREAMER_LITE
   GDestroyNotify destroy_entry;
   gpointer padding[21];                 /* padding for allowing e.g. systemclock
                                          * to add data in lieu of overridable

--- a/modules/javafx.media/src/main/native/gstreamer/plugins/av/videodecoder.c
+++ b/modules/javafx.media/src/main/native/gstreamer/plugins/av/videodecoder.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -199,7 +199,7 @@ static void videodecoder_dispose(GObject* object)
 {
     VideoDecoder *decoder = VIDEODECODER(object);
 
-    basedecoder_close_decoder(decoder);
+    basedecoder_close_decoder(BASEDECODER(decoder));
 
     G_OBJECT_CLASS(parent_class)->dispose(object);
 }
@@ -545,7 +545,7 @@ static gboolean videodecoder_convert_frame(VideoDecoder *decoder)
         return FALSE;
 
     int ret = decoder->sws_scale_func(decoder->sws_context,
-                                      base->frame->data,
+                                      (const uint8_t * const*)base->frame->data,
                                       base->frame->linesize,
                                       0,
                                       base->frame->height,


### PR DESCRIPTION
Clean backport of JDK-8354336.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354336](https://bugs.openjdk.org/browse/JDK-8354336) needs maintainer approval

### Issue
 * [JDK-8354336](https://bugs.openjdk.org/browse/JDK-8354336): gstclock.c: compilation error: 'incompatible pointer type' with gcc 14 (**Bug** - P3 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/26.diff">https://git.openjdk.org/jfx24u/pull/26.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/26#issuecomment-2831516585)
</details>
