### PR TITLE
8354940: Fail to sign in to Microsoft sites with WebView

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -622,6 +622,9 @@ defineProperty("PROMOTED_BUILD_NUMBER", "0")
 defineProperty("MILESTONE_FCS", "false")
 ext.IS_MILESTONE_FCS = Boolean.parseBoolean(MILESTONE_FCS)
 
+// The following property used to define WebView Browser Version
+defineProperty("WEBVIEW_VERSION", "18.4")
+
 // The following properties define the product name for Oracle JDK and OpenJDK
 // for VersionInfo and the DLL manifest.
 if (BUILD_CLOSED) {
@@ -4016,6 +4019,7 @@ project(":web") {
                     } else {
                         targetCpuBitDepthSwitch = "--32-bit"
                     }
+                    cmakeArgs += " -DWEBVIEW_BROWSER_VERSION=${WEBVIEW_VERSION}"
                     cmakeArgs += " -DJAVAFX_RELEASE_VERSION=${jfxReleaseMajorVersion}"
                     commandLine("perl", "$projectDir/src/main/native/Tools/Scripts/build-webkit",
                         "--java", "--icu-unicode", targetCpuBitDepthSwitch,

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPage.cpp
@@ -729,6 +729,7 @@ static String defaultUserAgent()
         String wkVersion = makeString(
                               WTF::String::number(WEBKIT_MAJOR_VERSION), WTF::String::fromLatin1("."), WTF::String::number(WEBKIT_MINOR_VERSION),
                               WTF::String::fromLatin1(" (KHTML, like Gecko) JavaFX/"), WTF::String::fromLatin1(JAVAFX_RELEASE_VERSION),
+                              WTF::String::fromLatin1(" Version/"), WTF::String::fromLatin1(WEBVIEW_BROWSER_VERSION),
                               WTF::String::fromLatin1(" Safari/"), WTF::String::number(WEBKIT_MAJOR_VERSION), WTF::String::fromLatin1("."),  WTF::String::number(WEBKIT_MINOR_VERSION));
         return makeString(WTF::String::fromLatin1("Mozilla/5.0 ("), agentOS(), WTF::String::fromLatin1(") AppleWebKit/"), wkVersion);
     }();

--- a/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPageConfig.h.in
+++ b/modules/javafx.web/src/main/native/Source/WebKitLegacy/java/WebCoreSupport/WebPageConfig.h.in
@@ -25,6 +25,13 @@
 
 #pragma once
 
+#cmakedefine WEBVIEW_BROWSER_VERSION "@WEBVIEW_BROWSER_VERSION@"
+
+#if !defined(WEBVIEW_BROWSER_VERSION)
+#error "WebView browser version not defined"
+#endif
+
+
 #cmakedefine JAVAFX_RELEASE_VERSION "@JAVAFX_RELEASE_VERSION@"
 
 #if !defined(JAVAFX_RELEASE_VERSION)


### PR DESCRIPTION
A clean backport to jfx24u. This is a webkit fix, need to be back ported for the sources sync with the mainline.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] [JDK-8354940](https://bugs.openjdk.org/browse/JDK-8354940) needs maintainer approval

### Issue
 * [JDK-8354940](https://bugs.openjdk.org/browse/JDK-8354940): Fail to sign in to Microsoft sites with WebView (**Bug** - P4 - Approved)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/27/head:pull/27` \
`$ git checkout pull/27`

Update a local copy of the PR: \
`$ git checkout pull/27` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/27/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 27`

View PR using the GUI difftool: \
`$ git pr show -t 27`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/27.diff">https://git.openjdk.org/jfx24u/pull/27.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/27#issuecomment-2929568658)
</details>
