### PR TITLE
8361887: Create release notes for JavaFX 24.0.2

### DIFF
--- a/doc-files/release-notes-24.0.2.md
+++ b/doc-files/release-notes-24.0.2.md
@@ -21,6 +21,4 @@ Issue key | Summary | Subcomponent
 
 ## List of Security fixes
 
-Issue key | Summary | Subcomponent
---------- | ------- | ------------
-JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT
+NONE

--- a/doc-files/release-notes-24.0.2.md
+++ b/doc-files/release-notes-24.0.2.md
@@ -1,0 +1,26 @@
+# Release Notes for JavaFX 24.0.2
+
+## Introduction
+
+The following notes describe important changes and information about this release. In some cases, the descriptions provide links to additional detailed information about an issue or a change.
+
+These notes document the JavaFX 24.0.2 update release. As such, they complement the [JavaFX 24](https://github.com/openjdk/jfx24u/blob/master/doc-files/release-notes-24.md) and [JavaFX 24.0.1](https://github.com/openjdk/jfx24u/blob/master/doc-files/release-notes-24.0.1.md) release notes.
+
+## List of Fixed Bugs
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+[JDK-8318985](https://bugs.openjdk.org/browse/JDK-8318985) | [macos] Incorrect 3D lighting on macOS 14 and later | graphics
+[JDK-8350284](https://bugs.openjdk.org/browse/JDK-8350284) | WebKit 620.1 crashes on startup on Windows x86 32-bit | web
+[JDK-8352162](https://bugs.openjdk.org/browse/JDK-8352162) | Update libxml2 to 2.13.8 | web
+[JDK-8352164](https://bugs.openjdk.org/browse/JDK-8352164) | Update libxslt to 1.1.43 | web
+[JDK-8353916](https://bugs.openjdk.org/browse/JDK-8353916) | Unexpected event type for DOM mutation events with WebKit 620.1 | web
+[JDK-8354876](https://bugs.openjdk.org/browse/JDK-8354876) | Update SQLite to 3.49.1 | web
+[JDK-8354940](https://bugs.openjdk.org/browse/JDK-8354940) | Fail to sign in to Microsoft sites with WebView | web
+
+
+## List of Security fixes
+
+Issue key | Summary | Subcomponent
+--------- | ------- | ------------
+JDK-nnnnnnn (not public) | TITLE | SUBCOMPONENT


### PR DESCRIPTION
Release notes for JavaFX 24.0.2.

Notes to reviewers:

I used the following filter to pick the issues:

https://bugs.openjdk.org/issues/?filter=47734

The original filter, with the backport IDs, is here:

https://bugs.openjdk.org/issues/?filter=47733

As usual, I excluded test bugs, cleanup bugs, etc.

NOTE: Once the CPU release ships on 2025-07-15, I will add any security bugs and ask for a re-review.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] [JDK-8361887](https://bugs.openjdk.org/browse/JDK-8361887) needs maintainer approval
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8361887](https://bugs.openjdk.org/browse/JDK-8361887): Create release notes for JavaFX 24.0.2 (**Task** - P2 - Approved)


### Reviewers
 * [Andy Goryachev](https://openjdk.org/census#angorya) (@andy-goryachev-oracle - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abhinayagarwal (no known openjdk.org user name / role) Review applies to [2b4e4376](https://git.openjdk.org/jfx24u/pull/28/files/2b4e4376c90b20762e0217f31f5b52dbcf06435d)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jfx24u.git pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/jfx24u.git pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jfx24u/pull/28.diff">https://git.openjdk.org/jfx24u/pull/28.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jfx24u/pull/28#issuecomment-3057979097)
</details>
